### PR TITLE
docs: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,7 +121,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v6
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,3 +107,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew publish -x test
+
+  # ===========================
+  # 4) Deploy — GitHub Pages
+  # ===========================
+  deploy-pages:
+    name: Deploy Documentation to GitHub Pages
+    needs: ci
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/latest
+          publish_branch: gh-pages


### PR DESCRIPTION
# 📝 Pull Request

## 📘 Description
Adds a GitHub Actions workflow step to deploy the documentation to GitHub Pages. The docs/latest folder will be published to the gh-pages branch automatically after a successful CI run. This allows the documentation site to be updated seamlessly with every change to the latest docs.

## 🎯 Motivation
Currently, the documentation is served manually or via redirects. Automating the deployment ensures that the latest documentation is always live on GitHub Pages without manual intervention, improving developer experience and reducing errors.

## 🔍 Type of Change
Select one:
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor (no behavior changes)
- [x] Documentation
- [x] Build / CI
- [ ] Breaking change

## 🧩 Summary of Changes
Added deploy-pages job to the GitHub Actions workflow.
Uses peaceiris/actions-gh-pages@v6 to publish docs/latest to gh-pages.
Ensures the deployment runs after successful CI.
GITHUB_TOKEN used for authentication to allow automatic deploymen

## 🧪 Tests
- [ ] Added tests
- [ ] Updated tests
- [x] Manual testing done

If manual testing was needed, steps:
1.
2.
3.

## 📦 Dependencies (if any)
none

## ✔️ Checklist
- [ ] Code builds and tests pass
- [ ] Documentation updated if needed
- [ ] Follows project coding style
